### PR TITLE
docs(guide): component example update

### DIFF
--- a/docs/content/guide/component.ngdoc
+++ b/docs/content/guide/component.ngdoc
@@ -39,14 +39,8 @@ Components can be registered using the `.component()` method of an AngularJS mod
   });
 </file>
 <file name="heroDetail.js">
-
-  function HeroDetailController() {
-
-  }
-
   angular.module('heroApp').component('heroDetail', {
     templateUrl: 'heroDetail.html',
-    controller: HeroDetailController,
     bindings: {
       hero: '='
     }


### PR DESCRIPTION
There is no need empty function on components controller anymore. Components are had a empty controller by the default.